### PR TITLE
Adds Thaumcraft Inventory Scanning

### DIFF
--- a/mods/tcinventoryscan-mc1.7.10-1.0.11.jar
+++ b/mods/tcinventoryscan-mc1.7.10-1.0.11.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f7ddf60d19903c99b6e72f7ae52fad7484999e72affc6ff0559b0502ec7dfad
+size 17202


### PR DESCRIPTION
Now i opened this for one reason: To make it less painful to scan chests of items. No need to drop items(And potentially have them hang in the air for minutes or delete when an item clearup occurs), just scanning with the scanner in the inventory itself.
Thats it.